### PR TITLE
#167081494 Build out the Get Trips filtered by Origin Endpoint

### DIFF
--- a/server/src/controllers/trips.js
+++ b/server/src/controllers/trips.js
@@ -4,6 +4,7 @@ import {
 } from '../utils/response';
 import { log } from '../utils';
 
+
 class Trips {
   static tripModel() {
     return new Model('trips');
@@ -39,9 +40,20 @@ class Trips {
 
   static async getAllTrips(req, res) {
     try {
-      const data = await Trips.tripModel().select('*');
-      if (!data[0]) return nullResponse(res, 'No trips available');
-      return successResponse(res, 200, data);
+      const { origin } = req.query;
+      switch (false) {
+        case !origin: {
+          const data = await Trips.tripModel().select('*', `WHERE origin='${origin}'`);
+          if (!data[0]) return nullResponse(res, 'No trip available from this location');
+          return successResponse(res, 200, data);
+        }
+
+        default: {
+          const data = await Trips.tripModel().select('*');
+          if (!data[0]) return nullResponse(res, 'No trips available');
+          return successResponse(res, 200, data);
+        }
+      }
     } catch (error) {
       return internalErrREesponse(res);
     }

--- a/server/src/middleware/trips-validate.js
+++ b/server/src/middleware/trips-validate.js
@@ -1,4 +1,4 @@
-import { check, param } from 'express-validator';
+import { check, param, query } from 'express-validator';
 
 const createTripValidate = [
   check('bus_id').not().isEmpty()
@@ -33,4 +33,11 @@ const cancelTripValidate = [
     .withMessage('Invalid trip ID'),
 ];
 
-export { createTripValidate, cancelTripValidate };
+const getTripValidate = [
+  query('origin').optional().matches(/^[\w',-\\/.\s]*$/)
+    .withMessage('Origin must be alphabets')
+    .isLength({ min: 3, max: 25 })
+    .withMessage('Origin should be between 3 and 25 characters'),
+];
+
+export { createTripValidate, cancelTripValidate, getTripValidate };

--- a/server/src/middleware/validate.js
+++ b/server/src/middleware/validate.js
@@ -2,7 +2,7 @@ import { check, validationResult } from 'express-validator';
 import { badRequestResponse } from '../utils/response';
 import signinValidate from './auth-validate';
 import busesValidate from './buses-validate';
-import { createTripValidate, cancelTripValidate } from './trips-validate';
+import { createTripValidate, cancelTripValidate, getTripValidate } from './trips-validate';
 
 
 class Validate {
@@ -65,6 +65,9 @@ class Validate {
 
       case 'createTrip':
         return createTripValidate;
+
+      case 'getTrip':
+        return getTripValidate;
 
       case 'cancelTrip':
         return cancelTripValidate;

--- a/server/src/routes/trips.js
+++ b/server/src/routes/trips.js
@@ -11,7 +11,7 @@ const { verifyAdmin, verifyUser } = Authorization;
 
 router.post('/', verifyAdmin, validate('createTrip'), checkValidationResult, createTrip);
 
-router.get('/', verifyUser, getAllTrips);
+router.get('/', verifyUser, validate('getTrip'), checkValidationResult, getAllTrips);
 
 router.patch('/:trip_id', verifyAdmin, validate('cancelTrip'), checkValidationResult, cancelTrip);
 

--- a/server/test/trips.spec.js
+++ b/server/test/trips.spec.js
@@ -281,6 +281,19 @@ describe('GET /trips', () => {
       });
   });
 
+  describe('GET /trips?origin', () => {
+    it('should return a trip that meets the origin query conditon', (done) => {
+      request.get('/api/v1/trips?origin=Abule Egba').set('Authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.be.an('object');
+          expect(res.body.data).to.be.an('array');
+          done();
+        });
+    });
+  });
+
   describe('CANNOT GET /trips', () => {
     before((done) => {
       pool.query('TRUNCATE ONLY trips RESTART IDENTITY CASCADE');


### PR DESCRIPTION
#### What does this PR do?
Have the Get Trips filtered by origin endpoint implemented

#### Description of Task to be completed?
Have the following endpoint working
`GET /api/v1/trips?origin`

#### How should this be manually tested?
After cloning the repo,
* `cd wayfarer`
* Run `npm run start:dev` on the console while in the wayfarer directory
* Authorization header should be set as *Bearer Token*; token is gotten from signing in as user or admin
* On Postman, make a HTTP GET `http://localhost:4800/api/v1/trips/?origin=Meiran`
* `origin` could be any origin location present in the database

#### Any background context you want to provide?
This endpoint gives the possibility of filtering data returned by origin

#### What are the relevant pivotal tracker stories?
[#167081494](https://www.pivotaltracker.com/story/show/167081494)
