### PR TITLE
#167081493 Build out the Get Trip filtered by Destination Endpoint

### DIFF
--- a/server/src/controllers/trips.js
+++ b/server/src/controllers/trips.js
@@ -40,11 +40,17 @@ class Trips {
 
   static async getAllTrips(req, res) {
     try {
-      const { origin } = req.query;
+      const { origin, destination } = req.query;
       switch (false) {
         case !origin: {
           const data = await Trips.tripModel().select('*', `WHERE origin='${origin}'`);
           if (!data[0]) return nullResponse(res, 'No trip available from this location');
+          return successResponse(res, 200, data);
+        }
+
+        case !destination: {
+          const data = await Trips.tripModel().select('*', `WHERE destination='${destination}'`);
+          if (!data[0]) return nullResponse(res, 'No trips available to this destination');
           return successResponse(res, 200, data);
         }
 

--- a/server/src/middleware/trips-validate.js
+++ b/server/src/middleware/trips-validate.js
@@ -38,6 +38,11 @@ const getTripValidate = [
     .withMessage('Origin must be alphabets')
     .isLength({ min: 3, max: 25 })
     .withMessage('Origin should be between 3 and 25 characters'),
+
+  query('destination').optional().matches(/^[\w',-\\/.\s]*$/)
+    .withMessage('Destination must be alphabets')
+    .isLength({ min: 3, max: 25 })
+    .withMessage('Destination should be between 3 and 25 characters'),
 ];
 
 export { createTripValidate, cancelTripValidate, getTripValidate };

--- a/server/test/trips.spec.js
+++ b/server/test/trips.spec.js
@@ -281,9 +281,20 @@ describe('GET /trips', () => {
       });
   });
 
-  describe('GET /trips?origin', () => {
+  describe('GET /trips?query', () => {
     it('should return a trip that meets the origin query conditon', (done) => {
       request.get('/api/v1/trips?origin=Abule Egba').set('Authorization', `Bearer ${adminToken}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.be.an('object');
+          expect(res.body.data).to.be.an('array');
+          done();
+        });
+    });
+
+    it('should return a trip that meets the destination query conditon', (done) => {
+      request.get('/api/v1/trips?destination=Lekki').set('Authorization', `Bearer ${adminToken}`)
         .end((err, res) => {
           expect(res.status).to.equal(200);
           expect(res.body.status).to.equal('success');


### PR DESCRIPTION
#### What does this PR do?
Have the Get Trips filtered by destination endpoint implemented

#### Description of Task to be completed?
Have the following endpoint working
`GET /api/v1/trips?destination`

#### How should this be manually tested?
After cloning the repo,
* `cd wayfarer`
* Run `npm run start:dev` on the console while in the wayfarer directory
* Authorization header should be set as *Bearer Token*; token is gotten from signing in as user or admin
* On Postman, make an HTTP GET `http://localhost:4800/api/v1/trips/?destination=Lekki`
* `destination` could be any destination location present in the database

#### Any background context you want to provide?
This endpoint gives the possibility of destination filtered data.

#### What are the relevant pivotal tracker stories?
[#167081493](https://www.pivotaltracker.com/story/show/167081493)
