### PR TITLE
 #167251228 Add bus Year of manufacture to existing Add Bus endpoint field

### DIFF
--- a/server/src/controllers/buses.js
+++ b/server/src/controllers/buses.js
@@ -10,10 +10,10 @@ class Buses {
 
   static async addBus(req, res) {
     const {
-      number_plate, manufacturer, model, capacity,
+      number_plate, manufacturer, year, model, capacity,
     } = req.body;
-    const columns = 'number_plate, manufacturer, model, capacity';
-    const values = `'${number_plate}', '${manufacturer}', '${model}', ${capacity}`;
+    const columns = 'number_plate, manufacturer, year, model, capacity';
+    const values = `'${number_plate}', '${manufacturer}', ${year}, '${model}', ${capacity}`;
     const clause = 'RETURNING *';
     try {
       const data = await Buses.Model().insert(columns, values, clause);

--- a/server/src/middleware/buses-validate.js
+++ b/server/src/middleware/buses-validate.js
@@ -11,6 +11,14 @@ export default [
     .isLength({ min: 2, max: 25 })
     .withMessage('Manufacturer should be between 3 and 25 characters'),
 
+  check('year').not().isEmpty()
+    .withMessage('Year is required')
+    .trim()
+    .isNumeric()
+    .withMessage('Capacity must be an integer')
+    .isInt({ min: 2005, max: 2020 })
+    .withMessage('Year of manufacture must be between 2005 and 2020'),
+
   check('model').not().isEmpty()
     .withMessage('Model is required'),
 

--- a/server/src/schema/migration.js
+++ b/server/src/schema/migration.js
@@ -38,6 +38,7 @@ const migration = async () => {
       id SERIAL PRIMARY KEY,
       number_plate TEXT UNIQUE NOT NULL,
       manufacturer TEXT NOT NULL,
+      year INTEGER NOT NULL CHECK (year >= 2005 AND year <= 2020) , 
       model TEXT NOT NULL,
       capacity INTEGER NOT NULL
     );
@@ -64,7 +65,6 @@ const migration = async () => {
     log('Creating Admin...');
     seedAdmin();
     log('Admin Created!');
-    
   } catch (error) {
     log(error.message);
   }

--- a/server/src/schema/seed.js
+++ b/server/src/schema/seed.js
@@ -10,9 +10,9 @@ const seed = async () => {
   INSERT INTO users (first_name, last_name, email, password) VALUES ('Wick', 'Maiden', 'wick@gmail.com', '${password}');
   INSERT INTO users (first_name, last_name, email, password) VALUES ('James', 'Morris', 'jmorris@hotmail.com', '${password}');
  
-  INSERT INTO buses (number_plate, manufacturer, model, capacity) VALUES ('DV345BG', 'Volvo', 'AR150', 30);
-  INSERT INTO buses (number_plate, manufacturer, model, capacity) VALUES ('DV345BD', 'Mercedes', 'Marcopolo', 30);
-  INSERT INTO buses (number_plate, manufacturer, model, capacity) VALUES ('DV345BC', 'Toyota', 'Hilux', 30);
+  INSERT INTO buses (number_plate, manufacturer, year, model, capacity) VALUES ('DV345BG', 'Volvo', 2015, 'AR150', 30);
+  INSERT INTO buses (number_plate, manufacturer, year, model, capacity) VALUES ('DV345BD', 'Mercedes', 2008, 'Marcopolo', 30);
+  INSERT INTO buses (number_plate, manufacturer, year, model, capacity) VALUES ('DV345BC', 'Toyota', 2010, 'Hilux', 30);
 
   INSERT INTO trips (bus_id, origin, destination, fare) VALUES (1, 'Ipaja', 'Lekki', 200);
   INSERT INTO trips (bus_id, origin, destination, fare) VALUES (2, 'Ijaiye', 'Magodo', 300);

--- a/server/test/buses.spec.js
+++ b/server/test/buses.spec.js
@@ -30,6 +30,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA458YU',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -47,6 +48,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA458YU',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -65,6 +67,7 @@ describe('POST /buses', () => {
   it('should throw error if number plate is missing', (done) => {
     const newBus = {
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -83,6 +86,7 @@ describe('POST /buses', () => {
   it('should throw error if manufacturer is missing', (done) => {
     const newBus = {
       number_plate: 'DA458YU',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -98,10 +102,30 @@ describe('POST /buses', () => {
       });
   });
 
+  it('should throw error if year is missing', (done) => {
+    const newBus = {
+      number_plate: 'DA458YU',
+      manufacturer: 'volvo',
+      model: 'Arial150',
+      capacity: 100,
+    };
+    request.post('/api/v1/buses').send(newBus)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.error).to.exist;
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.equal('Year is required');
+        done();
+      });
+  });
+
   it('should throw error if model is missing', (done) => {
     const newBus = {
       number_plate: 'DA458YU',
       manufacturer: 'volvo',
+      year: 2010,
       capacity: 100,
     };
     request.post('/api/v1/buses').send(newBus)
@@ -120,6 +144,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA458YU',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
     };
     request.post('/api/v1/buses').send(newBus)
@@ -138,6 +163,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA460',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -157,6 +183,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA460YA',
       manufacturer: 'v',
+      year: 2010,
       model: 'Arial150',
       capacity: 100,
     };
@@ -176,6 +203,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA460YA',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 'two',
     };
@@ -195,6 +223,7 @@ describe('POST /buses', () => {
     const newBus = {
       number_plate: 'DA460YA',
       manufacturer: 'volvo',
+      year: 2010,
       model: 'Arial150',
       capacity: 2,
     };


### PR DESCRIPTION
#### What does this PR do?
Have the `year` field included in Add Buses endpoint fields

#### Description of Task to be completed?
Have the following endpoint working
`POST /api/v1/buses`

#### How should this be manually tested?
After cloning the repo,
* `cd wayfarer`
* Run `npm run start:dev` on the console while in the wayfarer directory
* On Postman, make a HTTP POST `http://localhost:4800/api/v1/auth/signin/`
with request body 
```javascript
{
    "email": "admin@wayfarer.com",
    "password": "wayfarer10",
}
```
* Copy the token in the response body and add the token to Authorization header
*key*: Authorization      *value*: Bearer token
* Then make a HTTP POST `http://localhost:4800/api/v1/buses`
with request body 
```javascript
{
    "number_plate": "AD345LK",
    "manufacturer": "Mercedes",
    "year": 2011,  //This is the newly added field
    "model": "Marco Polo",
    "capacity": 50
}
```

#### Any background context you want to provide?
The endpoint now includes a field that takes in the bus' year of manufacture

#### What are the relevant pivotal tracker stories?
[#167251228](https://www.pivotaltracker.com/story/show/167251228)
