### PR TITLE
#167271042 Add trip date field to Create Trips request body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4894,6 +4894,11 @@
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.17.1",
     "express-validator": "^6.0.1",
     "jsonwebtoken": "^8.5.1",
+    "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "pg": "^7.11.0",
     "swagger-ui-express": "^4.0.7",

--- a/server/src/controllers/trips.js
+++ b/server/src/controllers/trips.js
@@ -2,6 +2,7 @@ import { Model } from '../models';
 import {
   conflictResponse, internalErrREesponse, successResponse, nullResponse,
 } from '../utils/response';
+import { log } from '../utils';
 
 /**
  * @description houses the methods for the trips endpoint
@@ -26,12 +27,12 @@ class Trips {
   */
   static async createTrip(req, res) {
     const {
-      bus_id, origin, destination, fare,
+      bus_id, origin, destination, trip_date, fare,
     } = req.body;
     const tripColumns = 'bus_id, origin, destination, status';
     const tripClause = `WHERE bus_id=${bus_id}`;
-    const columns = 'bus_id, origin, destination, fare';
-    const values = `${bus_id}, '${origin}', '${destination}', ${fare}`;
+    const columns = 'bus_id, origin, destination, trip_date, fare';
+    const values = `${bus_id}, '${origin}', '${destination}', '${trip_date}', ${fare}`;
     const clause = 'RETURNING *';
 
     try {
@@ -41,6 +42,9 @@ class Trips {
       if (tripExist[0] && tripExist[0].status === 'active') {
         return conflictResponse(res, 'This trip is already created');
       }
+      // if (!moment(new Date(trip_date), 'YYYY-MM-DD').isBefore(moment(), 'day')) {
+      //   return badRequestResponse(res, 'You cannot create a trip in the past');
+      // }
       const makeTrip = await Trips.tripModel().insert(columns, values, clause);
       return successResponse(res, 200, { ...makeTrip[0] });
     } catch (error) {

--- a/server/src/middleware/trips-validate.js
+++ b/server/src/middleware/trips-validate.js
@@ -23,6 +23,9 @@ const createTripValidate = [
     .isLength({ min: 2, max: 50 })
     .withMessage('Destination should be between 2 to 50 characters'),
 
+  check('trip_date').not().isEmpty()
+    .withMessage('Trip date is required'),
+
   check('fare').not().isEmpty()
     .withMessage('Fare is required')
     .isNumeric()

--- a/server/src/schema/migration.js
+++ b/server/src/schema/migration.js
@@ -29,7 +29,7 @@ const migration = async () => {
       bus_id INTEGER NOT NULL,
       origin TEXT NOT NULL,
       destination TEXT NOT NULL,
-      trip_date TIMESTAMP NOT NULL DEFAULT NOW(),
+      trip_date DATE NOT NULL,
       fare NUMERIC(6, 2) NOT NULL,
       status TEXT DEFAULT 'active' NOT NULL
     );

--- a/server/src/schema/seed.js
+++ b/server/src/schema/seed.js
@@ -14,9 +14,9 @@ const seed = async () => {
   INSERT INTO buses (number_plate, manufacturer, year, model, capacity) VALUES ('DV345BD', 'Mercedes', 2008, 'Marcopolo', 30);
   INSERT INTO buses (number_plate, manufacturer, year, model, capacity) VALUES ('DV345BC', 'Toyota', 2010, 'Hilux', 30);
 
-  INSERT INTO trips (bus_id, origin, destination, fare) VALUES (1, 'Ipaja', 'Lekki', 200);
-  INSERT INTO trips (bus_id, origin, destination, fare) VALUES (2, 'Ijaiye', 'Magodo', 300);
-  INSERT INTO trips (bus_id, origin, destination, fare) VALUES (3, 'Oshodi', 'FESTAC', 500);
+  INSERT INTO trips (bus_id, origin, destination, trip_date, fare) VALUES (1, 'Ipaja', 'Lekki', '2019/07/13', 200);
+  INSERT INTO trips (bus_id, origin, destination, trip_date, fare) VALUES (2, 'Ijaiye', 'Magodo', '2019/07/13', 300);
+  INSERT INTO trips (bus_id, origin, destination, trip_date, fare) VALUES (3, 'Oshodi', 'FESTAC', '2019/07/13', 500);
   `;
 
     log('Seeding Tables...');

--- a/server/test/trips.spec.js
+++ b/server/test/trips.spec.js
@@ -32,6 +32,7 @@ describe('POST /trips', () => {
       bus_id: 4,
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 1000,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -49,6 +50,7 @@ describe('POST /trips', () => {
       bus_id: 4,
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 1000,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -67,6 +69,7 @@ describe('POST /trips', () => {
     const newTrip = {
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 1000,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -85,6 +88,7 @@ describe('POST /trips', () => {
     const newTrip = {
       bus_id: 2,
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 1000,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -103,6 +107,7 @@ describe('POST /trips', () => {
     const newTrip = {
       bus_id: 3,
       origin: 'Abule Egba',
+      trip_date: '2019-12-16',
       fare: 1000,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -117,11 +122,31 @@ describe('POST /trips', () => {
       });
   });
 
+  it('should throw error if trip date is missing', (done) => {
+    const newTrip = {
+      bus_id: 3,
+      origin: 'Abule Egba',
+      destination: 'Lekki',
+      fare: 1000,
+    };
+    request.post('/api/v1/trips').send(newTrip)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .end((err, res) => {
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object');
+        expect(res.body.error).to.exist;
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.equal('Trip date is required');
+        done();
+      });
+  });
+
   it('should throw error if fare is missing', (done) => {
     const newTrip = {
       bus_id: 3,
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
     };
     request.post('/api/v1/trips').send(newTrip)
       .set('Authorization', `Bearer ${adminToken}`)
@@ -140,6 +165,7 @@ describe('POST /trips', () => {
       bus_id: 'five',
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 400,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -159,6 +185,7 @@ describe('POST /trips', () => {
       bus_id: 6,
       origin: 'A',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 400,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -178,6 +205,7 @@ describe('POST /trips', () => {
       bus_id: 6,
       origin: 'Abule Egba',
       destination: 'L',
+      trip_date: '2019-12-16',
       fare: 400,
     };
     request.post('/api/v1/trips').send(newTrip)
@@ -197,6 +225,7 @@ describe('POST /trips', () => {
       bus_id: 6,
       origin: 'Abule Egba',
       destination: 'Lekki',
+      trip_date: '2019-12-16',
       fare: 4,
     };
     request.post('/api/v1/trips').send(newTrip)


### PR DESCRIPTION
#### What does this PR do? 
Have the `trip_date` field included in Create Trips request body

#### Description of Task to be completed?
Add an extra field (trip_date) to Create Trips request body

#### How should this be manually tested?
Same with testing the `Create Trips` endpoint with `trip_date` included in the request body

#### Any background context you want to provide?
`trip_date` was auto generated as date the trip was created but now the admin can create trips for future dates

#### What are the relevant pivotal tracker stories?
[#167271042](https://www.pivotaltracker.com/story/show/167271042)
